### PR TITLE
Fix flattening, and use of deprecated .slurp on file handle

### DIFF
--- a/bin/abctranspose
+++ b/bin/abctranspose
@@ -34,7 +34,8 @@ sub Transpose($in, $out, $new-key-name, %old-key, %new-key, %shift, $shift) {
     }
 
     my $actions = ABC::Actions.new;
-    my $match = ABC::Grammar.parse($in.slurp, :rule<tune_file>, :$actions);
+
+    my $match = ABC::Grammar.parse($in.slurp-rest, :rule<tune_file>, :$actions);
     die "Did not match ABC grammar: last tune understood:\n { $actions.current-tune }" unless $match;
 
     for @( $match.ast ) -> $tune {

--- a/lib/ABC/KeyInfo.pm
+++ b/lib/ABC/KeyInfo.pm
@@ -84,7 +84,7 @@ class ABC::KeyInfo {
     }
 
     method scale-names is export {
-        ($.basenote .. "G", "A".."G")[^7];
+        ($.basenote .. "G", "A".."G").flat[^7];
     }
     
 }


### PR DESCRIPTION
This should fix the basic use of abctranspose
