### PR TITLE
Replace isa_ok with isa-ok

### DIFF
--- a/t/01-regexes.t
+++ b/t/01-regexes.t
@@ -4,7 +4,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse('"Cmin"', :rule<chord_or_text>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match,  '"Cmin" is a chord';
     is $match<chord>, "Cmin", '"Cmin" is chord Cmin';
     is $match<chord>[0]<basenote>, "C", '"Cmin" has base note C';
@@ -13,7 +13,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("^A,", :rule<pitch>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match,  '"^A," is a pitch';
     is $match<basenote>, "A", '"^A," has base note A';
     is $match<octave>, ",", '"^A," has octave ","';
@@ -22,7 +22,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("_B", :rule<pitch>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"_B" is a pitch';
     is $match<basenote>, "B", '"_B" has base note B';
     is $match<octave>, "", '"_B" has octave ""';
@@ -31,7 +31,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("C''", :rule<pitch>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"note" is a pitch';
     is $match<basenote>, "C", '"note" has base note C';
     is $match<octave>, "''", '"note" has octave two-upticks';
@@ -40,7 +40,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("=d,,,", :rule<pitch>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"=d,,," is a pitch';
     is $match<basenote>, "d", '"=d,,," has base note d';
     is $match<octave>, ",,,", '"=d,,," has octave ",,,"';
@@ -49,14 +49,14 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("2", :rule<note_length>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"2" is a note length';
     is $match, "2", '"2" has note length 2';
 }
 
 {
     my $match = ABC::Grammar.parse("^^e2", :rule<mnote>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"^^e2" is a note';
     is $match<pitch><basenote>, "e", '"^^e2" has base note e';
     is $match<pitch><octave>, "", '"^^e2" has octave ""';
@@ -66,7 +66,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("__f'/", :rule<mnote>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"__f/" is a note';
     is $match<pitch><basenote>, "f", '"__f/" has base note f';
     is $match<pitch><octave>, "'", '"__f/" has octave tick';
@@ -76,7 +76,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("G,2/3", :rule<mnote>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"G,2/3" is a note';
     is $match<pitch><basenote>, "G", '"G,2/3" has base note G';
     is $match<pitch><octave>, ",", '"G,2/3" has octave ","';
@@ -86,7 +86,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("z2/3", :rule<rest>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"z2/3" is a rest';
     is $match<rest_type>, "z", '"z2/3" has base rest z';
     is $match<note_length>, "2/3", '"z2/3" has note length 2/3';
@@ -94,7 +94,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("y/3", :rule<rest>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"y/3" is a rest';
     is $match<rest_type>, "y", '"y/3" has base rest y';
     is $match<note_length>, "/3", '"y/3" has note length 2/3';
@@ -102,7 +102,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("x", :rule<rest>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"x" is a rest';
     is $match<rest_type>, "x", '"x" has base rest x';
     is $match<note_length>, "", '"x" has no note length';
@@ -110,21 +110,21 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("+trill+", :rule<element>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"+trill+" is an element';
     is $match<gracing>, "+trill+", '"+trill+" gracing is +trill+';
 }
 
 {
     my $match = ABC::Grammar.parse("~", :rule<element>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"~" is an element';
     is $match<gracing>, "~", '"~" gracing is ~';
 }
 
 {
     my $match = ABC::Grammar.parse("z/", :rule<element>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"z/" is an element';
     is $match<rest><rest_type>, "z", '"z/" has base rest z';
     is $match<rest><note_length>, "/", '"z/" has length "/"';
@@ -132,21 +132,21 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("(", :rule<element>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"(" is an element';
     is $match<slur_begin>, '(', '"(" is a slur begin';
 }
 
 {
     my $match = ABC::Grammar.parse(")", :rule<element>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '")" is an element';
     is $match<slur_end>, ')', '")" is a slur end';
 }
 
 {
     my $match = ABC::Grammar.parse("_D,5/4", :rule<element>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"_D,5/4" is an element';
     is $match<stem><mnote>[0]<pitch><basenote>, "D", '"_D,5/4" has base note D';
     is $match<stem><mnote>[0]<pitch><octave>, ",", '"_D,5/4" has octave ","';
@@ -156,7 +156,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("A>^C'", :rule<broken_rhythm>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"A>^C" is a broken rhythm';
     is $match<stem>[0]<mnote>[0]<pitch><basenote>, "A", 'first note is A';
     is $match<stem>[0]<mnote>[0]<pitch><octave>, "", 'first note has no octave';
@@ -171,7 +171,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("d'+p+<<<+accent+_B", :rule<broken_rhythm>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"d+p+<<<+accent+_B" is a broken rhythm';
     given $match
     {
@@ -191,7 +191,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("(3abc", :rule<tuplet>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"(3abc" is a tuplet';
     is ~$match, "(3abc", '"(3abc" was the portion matched';
     is +@( $match<stem> ), 3, 'Three notes matched';
@@ -202,7 +202,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("(5abcde", :rule<tuplet>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"(5abcde" is a tuplet';
     is ~$match, "(5abcde", '"(5abcde" was the portion matched';
     is +@( $match<stem> ), 5, 'Three notes matched';
@@ -215,7 +215,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("[a2bc]3", :rule<stem>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"[a2bc]3" is a stem';
     is ~$match, "[a2bc]3", '"[a2bc]3" was the portion matched';
     is +@( $match<mnote> ), 3, 'Three notes matched';
@@ -228,7 +228,7 @@ use ABC::Grammar;
 
 {
     my $match = ABC::Grammar.parse("[a2bc]3-", :rule<stem>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, '"[a2bc]3-" is a stem';
     is ~$match, "[a2bc]3-", '"[a2bc]3-" was the portion matched';
     is +@( $match<mnote> ), 3, 'Three notes matched';
@@ -242,7 +242,7 @@ use ABC::Grammar;
 # (3 is the only case that works currently.  :(
 # {
 #     my $match = ABC::Grammar.parse("(2abcd", :rule<tuple>);
-#     isa_ok $match, Match, '"(2ab" is a tuple';
+#     isa-ok $match, Match, '"(2ab" is a tuple';
 #     is ~$match, "(2ab", '"(2ab" was the portion matched';
 #     is $match<stem>[0], "a", 'first note is a';
 #     is $match<stem>[1], "b", 'second note is b';
@@ -251,14 +251,14 @@ use ABC::Grammar;
 for ':|:', '|:', '|', ':|', '::', '|]' 
 {
     my $match = ABC::Grammar.parse($_, :rule<barline>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, "barline $_ recognized";
     is $match, $_, "barline $_ is correct";
 }
 
 {
     my $match = ABC::Grammar.parse("g>ecgece/f/g/e/|", :rule<bar>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'bar recognized';
     is $match, "g>ecgece/f/g/e/|", "Entire bar was matched";
     is $match<element>.for(~*), "g>e c g e c e/ f/ g/ e/", "Each element was matched";
@@ -267,7 +267,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 
 {
     my $match = ABC::Grammar.parse("g>ecg ec e/f/g/e/ |", :rule<bar>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'bar recognized';
     is $match, "g>ecg ec e/f/g/e/ |", "Entire bar was matched";
     is $match<element>.for(~*), "g>e c g   e c   e/ f/ g/ e/  ", "Each element was matched";
@@ -277,7 +277,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = "g>ecg ec e/f/g/e/ | d/c/B/A/ Gd BG B/c/d/B/ |";
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0], "g>ecg ec e/f/g/e/ |", "First bar is correct";
@@ -288,7 +288,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = "g>ecg ec e/f/g/e/ |1 d/c/B/A/ Gd BG B/c/d/B/ |";
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0], "g>ecg ec e/f/g/e/ |", "First bar is correct";
@@ -299,7 +299,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = "|A/B/c/A/ c>d e>deg | dB/A/ gB +trill+A2 +trill+e2 ::";
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0], "A/B/c/A/ c>d e>deg |", "First bar is correct";
@@ -311,7 +311,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = 'g>ecg ec e/f/g/e/ |[2-3 d/c/B/A/ {Gd} BG B/c/d/B/ |';
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0], "g>ecg ec e/f/g/e/ |", "First bar is correct";
@@ -321,7 +321,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 
 {
     my $match = ABC::Grammar.parse("[K:F]", :rule<inline_field>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'inline field recognized';
     is $match, "[K:F]", "Entire string was matched";
     is $match<alpha>, "K", "Correct field name found";
@@ -330,7 +330,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 
 {
     my $match = ABC::Grammar.parse("[M:3/4]", :rule<inline_field>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'inline field recognized';
     is $match, "[M:3/4]", "Entire string was matched";
     is $match<alpha>, "M", "Correct field name found";
@@ -339,14 +339,14 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 
 {
     my $match = ABC::Grammar.parse(" % this is a comment", :rule<comment_line>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'comment line recognized';
     is $match, " % this is a comment", "Entire string was matched";
 }
 
 {
     my $match = ABC::Grammar.parse("% this is a comment", :rule<comment_line>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'comment line recognized';
     is $match, "% this is a comment", "Entire string was matched";
 }
@@ -354,7 +354,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = "g>ecg ec e/f/g/e/ | d/c/B/A/ [K:F] Gd BG B/c/d/B/ |";
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0], "g>ecg ec e/f/g/e/ |", "First bar is correct";
@@ -366,7 +366,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = "g>ecg ec e/f/g/e/ | d/c/B/A/ [M:C] Gd BG B/c/d/B/ |";
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0], "g>ecg ec e/f/g/e/ |", "First bar is correct";
@@ -378,7 +378,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = "| [K:F] Gd BG [B/c/d/B/]|";
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[0]<element>[1], "[K:F]", "Key signature change is correctly captured";
@@ -388,7 +388,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
 {
     my $line = 'E2 CE GCEG|c4 B3 ^F|(A2 G2) =F2 D2|C4 {B,C}E2 D>E|[1 (D4 C2) z2:|[2 (D4 C2) z3/2 [G/2D/2]|';
     my $match = ABC::Grammar.parse($line, :rule<line_of_music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'line of music recognized';
     is $match, $line, "Entire line was matched";
     is $match<bar>[5]<element>[0], "[2", "nth repeat works";
@@ -400,7 +400,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
     g>ecg ec e/f/g/e/ | d/c/B/A/ Gd BG B/c/d/B/ | 
     g/f/e/d/ c/d/e/f/ gc e/f/g/e/ | dB/A/ gB +trill+A2 +trill+e2 :|»;
     my $match = ABC::Grammar.parse($music, :rule<music>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'music recognized';
     is $match<line_of_music>.elems, 4, "Four lines matched";
 }
@@ -415,7 +415,7 @@ L:1/8
 K:D
 »;
     my $match = ABC::Grammar.parse($music, :rule<header>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'header recognized';
     is $match<header_field>.elems, 6, "Six fields matched";
     is $match<header_field>.for({ .<header_field_name> }), "X T S M L K", "Got the right field names";
@@ -434,7 +434,7 @@ g>ecg ec e/f/g/e/ | d/c/B/A/ Gd BG B/c/d/B/ |
 g/f/e/d/ c/d/e/f/ gc e/f/g/e/ | dB/A/ gB +trill+A2 +trill+e2 :|
 »;
     my $match = ABC::Grammar.parse($music, :rule<tune>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'tune recognized';
     given $match<header>
     {
@@ -467,7 +467,7 @@ K:Edor
 |:AB cd|e4|AB cB|BA FA|AB cd|e4|AB cB|A2 A2:|
 »;
     my $match = ABC::Grammar.parse($music, :rule<tune_file>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'tune_file recognized';
     
     is $match<tune>.elems, 2, 'found two tunes';
@@ -497,7 +497,7 @@ K:Edor
 |:B E2 G|FE D2|E>F GA|Bc BA|B E2 G|FE D2|E>F GE|A2 A2:|
 |:AB cd|e4|AB cB|BA FA|AB cd|e4|AB cB|A2 A2:|»;
     my $match = ABC::Grammar.parse($music, :rule<tune_file>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'tune_file recognized';
     
     is $match<tune>.elems, 2, 'found two tunes';
@@ -516,7 +516,7 @@ K:D
 "D" f4 "A" e4|"Bm" d4 "F#m" c4|"G" B4 "D" A4|"G" B4 "A" c4|
 »;
     my $match = ABC::Grammar.parse($music, :rule<tune_file>);
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'tune_file recognized';
     
     is $match<tune>.elems, 1, 'found one tune';

--- a/t/04-header.t
+++ b/t/04-header.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use ABC::Header;
 
-isa_ok ABC::Header.new, ABC::Header, "Can create ABC::Header object";
+isa-ok ABC::Header.new, ABC::Header, "Can create ABC::Header object";
 
 {
     my $a = ABC::Header.new;

--- a/t/05-actions.t
+++ b/t/05-actions.t
@@ -14,7 +14,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse('F#', :rule<chord>, :actions(ABC::Actions.new));
     ok $match, 'chord recognized';
-    isa_ok $match.ast, ABC::Chord, '$match.ast is an ABC::Chord';
+    isa-ok $match.ast, ABC::Chord, '$match.ast is an ABC::Chord';
     is $match.ast.main-note, "F", "Pitch F";
     is $match.ast.main-accidental, "#", "...sharp";
 }
@@ -22,7 +22,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse('Bbmin/G#', :rule<chord>, :actions(ABC::Actions.new));
     ok $match, 'chord recognized';
-    isa_ok $match.ast, ABC::Chord, '$match.ast is an ABC::Chord';
+    isa-ok $match.ast, ABC::Chord, '$match.ast is an ABC::Chord';
     is $match.ast.main-note, "B", "Pitch B";
     is $match.ast.main-accidental, "b", "...flat";
     is $match.ast.main-type, "min", "...min";
@@ -33,7 +33,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse('"F#"', :rule<chord_or_text>, :actions(ABC::Actions.new));
     ok $match, 'chord_or_text recognized';
-    isa_ok $match.ast[0], ABC::Chord, '$match.ast[0] is an ABC::Chord';
+    isa-ok $match.ast[0], ABC::Chord, '$match.ast[0] is an ABC::Chord';
     is $match.ast[0].main-note, "F", "Pitch F";
     is $match.ast[0].main-accidental, "#", "...sharp";
 }
@@ -41,7 +41,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse('{gf}', :rule<grace_notes>, :actions(ABC::Actions.new));
     ok $match, 'grace_notes recognized';
-    isa_ok $match.ast, ABC::GraceNotes, '$match.ast is an ABC::GraceNotes';
+    isa-ok $match.ast, ABC::GraceNotes, '$match.ast is an ABC::GraceNotes';
     nok $match.ast.acciaccatura, "It's not an acciaccatura";
     is $match.ast.notes[0].pitch, "g", "Pitch g found";
     is $match.ast.notes[1].pitch, "f", "Pitch g found";
@@ -50,7 +50,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse('"F#"', :rule<element>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, Pair, '$match.ast is a Pair';
+    isa-ok $match.ast, Pair, '$match.ast is a Pair';
     is $match.ast.key, "chord_or_text", '$match.ast.key is "chord_or_text"';
     is $match.ast.value[0].main-note, "F", "Pitch F";
     is $match.ast.value[0].main-accidental, "#", "...sharp";
@@ -59,16 +59,16 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse('"^Bb whistle"', :rule<element>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, Pair, '$match.ast is a Pair';
+    isa-ok $match.ast, Pair, '$match.ast is a Pair';
     is $match.ast.key, "chord_or_text", '$match.ast.key is "chord_or_text"';
-    isa_ok $match.ast.value[0], Str, "And it's text";
+    isa-ok $match.ast.value[0], Str, "And it's text";
     is $match.ast.value[0], "^Bb whistle", '$match.ast.value[0] is ^Bb whistle';
 }
 
 {
     my $match = ABC::Grammar.parse("e3", :rule<mnote>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
+    isa-ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
     is $match.ast.pitch, "e", "Pitch e";
     is $match.ast.ticks, 3, "Duration 3 ticks";
 }
@@ -76,7 +76,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("e", :rule<mnote>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
+    isa-ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
     is $match.ast.pitch, "e", "Pitch e";
     is $match.ast.ticks, 1, "Duration 1 ticks";
 }
@@ -84,7 +84,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("^e,/", :rule<mnote>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
+    isa-ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
     is $match.ast.pitch, "^e,", "Pitch ^e,";
     is $match.ast.ticks, 1/2, "Duration 1/2 ticks";
 }
@@ -92,7 +92,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("[a2bc]3", :rule<stem>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Stem, '$match.ast is an ABC::Stem';
+    isa-ok $match.ast, ABC::Stem, '$match.ast is an ABC::Stem';
     is $match.ast.notes[0], "a2", "Pitch 1 a";
     is $match.ast.notes[1], "b", "Pitch 2 b";
     is $match.ast.notes[2], "c", "Pitch 3 c";
@@ -103,7 +103,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("[a2bc]/-", :rule<stem>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Stem, '$match.ast is an ABC::Stem';
+    isa-ok $match.ast, ABC::Stem, '$match.ast is an ABC::Stem';
     is $match.ast.notes[0], "a2", "Pitch 1 a";
     is $match.ast.notes[1], "b", "Pitch 2 b";
     is $match.ast.notes[2], "c", "Pitch 3 c";
@@ -114,7 +114,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("z/", :rule<rest>, :actions(ABC::Actions.new));
     ok $match, 'rest recognized';
-    isa_ok $match.ast, ABC::Rest, '$match.ast is an ABC::Rest';
+    isa-ok $match.ast, ABC::Rest, '$match.ast is an ABC::Rest';
     is $match.ast.type, "z", "Rest is z";
     is $match.ast.ticks, 1/2, "Duration 1/2 ticks";
 }
@@ -122,7 +122,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("F3/2", :rule<mnote>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
+    isa-ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
     is $match.ast.pitch, "F", "Pitch F";
     is $match.ast.ticks, 3/2, "Duration 3/2 ticks";
 }
@@ -130,7 +130,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("F2/3", :rule<mnote>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
+    isa-ok $match.ast, ABC::Note, '$match.ast is an ABC::Note';
     is $match.ast.pitch, "F", "Pitch F";
     is $match.ast.ticks, 2/3, "Duration 2/3 ticks";
 }
@@ -138,7 +138,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("(3abc", :rule<tuplet>, :actions(ABC::Actions.new));
     ok $match, 'tuplet recognized';
-    isa_ok $match.ast, ABC::Tuplet, '$match.ast is an ABC::Tuplet';
+    isa-ok $match.ast, ABC::Tuplet, '$match.ast is an ABC::Tuplet';
     is $match.ast.tuple, "3", "It's a triplet";
     is $match.ast.ticks, 2, "Duration 2 ticks";
     is +$match.ast.notes, 3, "Three internal note";
@@ -149,12 +149,12 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("a>~b", :rule<broken_rhythm>, :actions(ABC::Actions.new));
     ok $match, 'broken rhythm recognized';
-    isa_ok $match.ast, ABC::BrokenRhythm, '$match.ast is an ABC::BrokenRhythm';
+    isa-ok $match.ast, ABC::BrokenRhythm, '$match.ast is an ABC::BrokenRhythm';
     is $match.ast.ticks, 2, "total duration is two ticks";
-    isa_ok $match.ast.effective-stem1, ABC::Note, "effective-stem1 is a note";
+    isa-ok $match.ast.effective-stem1, ABC::Note, "effective-stem1 is a note";
     is $match.ast.effective-stem1.pitch, "a", "first pitch is a";
     is $match.ast.effective-stem1.ticks, 1.5, "first duration is 1 + 1/2";
-    isa_ok $match.ast.effective-stem2, ABC::Note, "effective-stem2 is a note";
+    isa-ok $match.ast.effective-stem2, ABC::Note, "effective-stem2 is a note";
     is $match.ast.effective-stem2.pitch, "b", "first pitch is a";
     is $match.ast.effective-stem2.ticks, .5, "second duration is 1/2";
 }
@@ -162,12 +162,12 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("a<<<b", :rule<broken_rhythm>, :actions(ABC::Actions.new));
     ok $match, 'broken rhythm recognized';
-    isa_ok $match.ast, ABC::BrokenRhythm, '$match.ast is an ABC::BrokenRhythm';
+    isa-ok $match.ast, ABC::BrokenRhythm, '$match.ast is an ABC::BrokenRhythm';
     is $match.ast.ticks, 2, "total duration is two ticks";
-    isa_ok $match.ast.effective-stem1, ABC::Note, "effective-stem1 is a note";
+    isa-ok $match.ast.effective-stem1, ABC::Note, "effective-stem1 is a note";
     is $match.ast.effective-stem1.pitch, "a", "first pitch is a";
     is $match.ast.effective-stem1.ticks, 1/8, "first duration is 1/8";
-    isa_ok $match.ast.effective-stem2, ABC::Note, "effective-stem2 is a note";
+    isa-ok $match.ast.effective-stem2, ABC::Note, "effective-stem2 is a note";
     is $match.ast.effective-stem2.pitch, "b", "first pitch is a";
     is $match.ast.effective-stem2.ticks, 15/8, "second duration is 1 + 7/8";
 }
@@ -175,7 +175,7 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("[K:F]", :rule<element>, :actions(ABC::Actions.new));
     ok $match, 'inline field recognized';
-    # isa_ok $match.ast, ABC::BrokenRhythm, '$match.ast is an ABC::BrokenRhythm';
+    # isa-ok $match.ast, ABC::BrokenRhythm, '$match.ast is an ABC::BrokenRhythm';
     is $match<inline_field><alpha>, "K", "field type is K";
     is $match<inline_field><value>, "F", "field value is K";
 }
@@ -183,21 +183,21 @@ use ABC::Chord;
 {
     my $match = ABC::Grammar.parse("+fff+", :rule<long_gracing>, :actions(ABC::Actions.new));
     ok $match, 'long gracing recognized';
-    isa_ok $match.ast, Str, '$match.ast is a Str';
+    isa-ok $match.ast, Str, '$match.ast is a Str';
     is $match.ast, "fff", "gracing is fff";
 }
 
 {
     my $match = ABC::Grammar.parse("+fff+", :rule<gracing>, :actions(ABC::Actions.new));
     ok $match, 'long gracing recognized';
-    isa_ok $match.ast, Str, '$match.ast is a Str';
+    isa-ok $match.ast, Str, '$match.ast is a Str';
     is $match.ast, "fff", "gracing is fff";
 }
 
 {
     my $match = ABC::Grammar.parse("~", :rule<gracing>, :actions(ABC::Actions.new));
     ok $match, 'gracing recognized';
-    isa_ok $match.ast, Str, '$match.ast is a Str';
+    isa-ok $match.ast, Str, '$match.ast is a Str';
     is $match.ast, "~", "gracing is ~";
 }
 
@@ -205,7 +205,7 @@ use ABC::Chord;
     my $match = ABC::Grammar.parse("+fff+", :rule<element>, :actions(ABC::Actions.new));
     ok $match, 'long gracing recognized';
     is $match.ast.key, "gracing", '$match.ast.key is gracing';
-    isa_ok $match.ast.value, Str, '$match.ast.value is a Str';
+    isa-ok $match.ast.value, Str, '$match.ast.value is a Str';
     is $match.ast.value, "fff", "gracing is fff";
 }
 
@@ -219,7 +219,7 @@ K:D
 »;
     my $match = ABC::Grammar.parse($music, :rule<header>, :actions(ABC::Actions.new));
     ok $match, 'tune recognized';
-    isa_ok $match.ast, ABC::Header, '$match.ast is an ABC::Header';
+    isa-ok $match.ast, ABC::Header, '$match.ast is an ABC::Header';
     is $match.ast.get("T").elems, 1, "One T field found";
     is $match.ast.get("T")[0].value, "Cuckold Come Out o' the Amrey", "And it's correct";
     ok $match.ast.is-valid, "ABC::Header is valid";
@@ -228,9 +228,9 @@ K:D
 {
     my $match = ABC::Grammar.parse("e3", :rule<element>, :actions(ABC::Actions.new));
     ok $match, 'element recognized';
-    isa_ok $match.ast, Pair, '$match.ast is a Pair';
+    isa-ok $match.ast, Pair, '$match.ast is a Pair';
     is $match.ast.key, "stem", "Stem found";
-    isa_ok $match.ast.value, ABC::Note, "Value is note";
+    isa-ok $match.ast.value, ABC::Note, "Value is note";
 }
 
 {
@@ -262,7 +262,7 @@ BAB G2G|G2g gdB|c2a B2g|A2=f fcA:|
     # say $match.ast[28].WHAT;
     # say $match.ast[28].perl;
     is $match.ast[22].key, "nth_repeat", "21st is nth_repeat";
-    isa_ok $match.ast[22].value, Set, "21st value is a Set";
+    isa-ok $match.ast[22].value, Set, "21st value is a Set";
     ok $match.ast[22].value ~~ (set 2), "21st is '2'";
     is $match.ast[30].key, "endline", "29th is endline";
     is $match.ast[*-1].key, "endline", "Last is endline";
@@ -300,7 +300,7 @@ BAB G2G|G2g gdB|c2a B2g|A2=f fcA:|
 
     my $match = ABC::Grammar.parse($music, :rule<tune>, :actions(ABC::Actions.new));
     ok $match, 'tune recognized';
-    isa_ok $match.ast, ABC::Tune, 'and ABC::Tune created';
+    isa-ok $match.ast, ABC::Tune, 'and ABC::Tune created';
     ok $match.ast.header.is-valid, "ABC::Tune's header is valid";
     is $match.ast.music.elems, 57, '$match.ast.music has 57 elements';
 }
@@ -311,7 +311,7 @@ BAB G2G|G2g gdB|c2a B2g|A2=f fcA:|
     # say $match.ast.perl;
     is @( $match<tune> ).elems, 3, "Three tunes were found";
     # is @( $match.ast )[0].elems, 3, "Three tunes were found";
-    isa_ok @( $match.ast )[0][0], ABC::Tune, "First is an ABC::Tune";
+    isa-ok @( $match.ast )[0][0], ABC::Tune, "First is an ABC::Tune";
 }
 
 {
@@ -324,7 +324,7 @@ K:D
 "D" DFAd "A" CEAc|"Bm" B,DFB "F#m" A,CFA|"G" B,DGB "D" A,DFA|"G" B,DGB "A" CEAc|
 "D" f4 "A" e4|"Bm" d4 "F#m" c4|"G" B4 "D" A4|"G" B4 "A" c4|»;
     my $match = ABC::Grammar.parse($music, :rule<tune_file>, :actions(ABC::Actions.new));
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'tune_file recognized';
     
     is $match<tune>.elems, 1, 'found one tune';

--- a/t/09-context.t
+++ b/t/09-context.t
@@ -8,7 +8,7 @@ use ABC::Actions;
     my $context = ABC::Context.new("C", "4/4", "1/8");
     
     my $match = ABC::Grammar.parse("abcdefgab^c_dcd", :rule<bar>, :actions(ABC::Actions.new));
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'bar recognized';
     
     # first run loads up C# and Db
@@ -36,7 +36,7 @@ use ABC::Actions;
     my $context = ABC::Context.new("C#", "4/4", "1/8");
     
     my $match = ABC::Grammar.parse("abcdefgab^c_dcd", :rule<bar>, :actions(ABC::Actions.new));
-    isa_ok $match, Match, 'Got a match';
+    isa-ok $match, Match, 'Got a match';
     ok $match, 'bar recognized';
     
     # first run loads up C# and Db


### PR DESCRIPTION
The kebab-case versions of the test functions are now the official test
functions; the test functions with underscores have been deprecated and will
be removed in the 2015.09 release of Rakudo.