### PR TITLE
Replace method for statement with flatmap

### DIFF
--- a/lib/ABC/Actions.pm
+++ b/lib/ABC/Actions.pm
@@ -142,8 +142,8 @@ class ABC::Actions {
     }
     
     method chord_or_text($/) {
-        my @chords = $/<chord>.for({ $_.ast });
-        my @texts = $/<text_expression>.for({ ~$_ });
+        my @chords = $/<chord>.flatmap({ $_.ast });
+        my @texts = $/<text_expression>.flatmap({ ~$_ });
         make (@chords, @texts).flat;
     }
     

--- a/lib/ABC/Utils.pm
+++ b/lib/ABC/Utils.pm
@@ -19,7 +19,7 @@ package ABC::Utils {
             }
             when "inline_field" { '[' ~ $element-pair.value.key ~ ':' ~ $element-pair.value.value ~ ']'; }
             when "chord_or_text" { 
-                $element-pair.value.for({
+                $element-pair.value.flatmap({
                     when Str { '"' ~ $_ ~ '"'; }
                     ~$_; 
                 }).join('') ; 

--- a/t/01-regexes.t
+++ b/t/01-regexes.t
@@ -261,7 +261,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
     isa_ok $match, Match, 'Got a match';
     ok $match, 'bar recognized';
     is $match, "g>ecgece/f/g/e/|", "Entire bar was matched";
-    is $match<element>.for(~*), "g>e c g e c e/ f/ g/ e/", "Each element was matched";
+    is $match<element>.flatmap(~*), "g>e c g e c e/ f/ g/ e/", "Each element was matched";
     is $match<barline>, "|", "Barline was matched";
 }
 
@@ -270,7 +270,7 @@ for ':|:', '|:', '|', ':|', '::', '|]'
     isa_ok $match, Match, 'Got a match';
     ok $match, 'bar recognized';
     is $match, "g>ecg ec e/f/g/e/ |", "Entire bar was matched";
-    is $match<element>.for(~*), "g>e c g   e c   e/ f/ g/ e/  ", "Each element was matched";
+    is $match<element>.flatmap(~*), "g>e c g   e c   e/ f/ g/ e/  ", "Each element was matched";
     is $match<barline>, "|", "Barline was matched";
 }
 
@@ -418,7 +418,7 @@ K:D
     isa_ok $match, Match, 'Got a match';
     ok $match, 'header recognized';
     is $match<header_field>.elems, 6, "Six fields matched";
-    is $match<header_field>.for({ .<header_field_name> }), "X T S M L K", "Got the right field names";
+    is $match<header_field>.flatmap({ .<header_field_name> }), "X T S M L K", "Got the right field names";
 }
 
 {
@@ -439,7 +439,7 @@ g/f/e/d/ c/d/e/f/ gc e/f/g/e/ | dB/A/ gB +trill+A2 +trill+e2 :|
     given $match<header>
     {
         is .<header_field>.elems, 6, "Six fields matched";
-        is .<header_field>.for({ .<header_field_name> }), "X T S M L K", "Got the right field names";
+        is .<header_field>.flatmap({ .<header_field_name> }), "X T S M L K", "Got the right field names";
     }
     is $match<music><line_of_music>.elems, 4, "Four lines matched";
 }

--- a/t/03-file.t
+++ b/t/03-file.t
@@ -7,7 +7,7 @@ use ABC::Grammar;
     ok $match, 'samples.abc is a valid tune file';
     is @( $match<tune> ).elems, 3, "Three tunes were found";
 
-    my @titles = @( $match<tune> ).for({ @( .<header><header_field> ).grep({ .<header_field_name> eq "T" })[0] }).for({ .<header_field_data> });
+    my @titles = @( $match<tune> ).flatmap({ @( .<header><header_field> ).grep({ .<header_field_name> eq "T" })[0] }).flatmap({ .<header_field_data> });
     
     is +@titles, 3, "Three titles were found";
     is @titles[0], "Cuckold Come Out o' the Amrey", "First is Cuckold";


### PR DESCRIPTION
The `for` method has been deprecated in favour of `flatmap`.  The old syntax
will be removed in Rakudo version 2015.09; this change removes the
deprecation warning emitted from the current version of Rakudo.