### PR TITLE
Flatten zip operator output explicitly

### DIFF
--- a/t/09-context.t
+++ b/t/09-context.t
@@ -12,13 +12,13 @@ use ABC::Actions;
     ok $match, 'bar recognized';
     
     # first run loads up C# and Db
-    for @($match.ast) Z ("" xx 9, "^", "_", "^", "_") -> $note, $desired-accidental {
+    for (@($match.ast) Z ("" xx 9, "^", "_", "^", "_")).flat -> $note, $desired-accidental {
         my $accidental = $context.working-accidental($note.value);
         is $accidental, $desired-accidental;
     }
     
     # second run still has them
-    for @($match.ast) Z ("", "", "^", "_", "", "", "", "", "", "^", "_", "^", "_") -> $note, $desired-accidental {
+    for (@($match.ast) Z ("", "", "^", "_", "", "", "", "", "", "^", "_", "^", "_")).flat -> $note, $desired-accidental {
         my $accidental = $context.working-accidental($note.value);
         is $accidental, $desired-accidental;
     }
@@ -26,7 +26,7 @@ use ABC::Actions;
     $context.bar-line;
 
     # and now we've reset to the initial state
-    for @($match.ast) Z ("" xx 9, "^", "_", "^", "_") -> $note, $desired-accidental {
+    for (@($match.ast) Z ("" xx 9, "^", "_", "^", "_")).flat -> $note, $desired-accidental {
         my $accidental = $context.working-accidental($note.value);
         is $accidental, $desired-accidental;
     }
@@ -40,13 +40,13 @@ use ABC::Actions;
     ok $match, 'bar recognized';
     
     # first run loads up C# and Db
-    for @($match.ast) Z ("^" xx 9, "^", "_", "^", "_") -> $note, $desired-accidental {
+    for (@($match.ast) Z ("^" xx 9, "^", "_", "^", "_")).flat -> $note, $desired-accidental {
         my $accidental = $context.working-accidental($note.value);
         is $accidental, $desired-accidental;
     }
     
     # second run still has them
-    for @($match.ast) Z ("^", "^", "^", "_", "^", "^", "^", "^", "^", "^", "_", "^", "_") -> $note, $desired-accidental {
+    for (@($match.ast) Z ("^", "^", "^", "_", "^", "^", "^", "^", "^", "^", "_", "^", "_")).flat -> $note, $desired-accidental {
         my $accidental = $context.working-accidental($note.value);
         is $accidental, $desired-accidental;
     }
@@ -54,7 +54,7 @@ use ABC::Actions;
     $context.bar-line;
 
     # and now we've reset to the initial state
-    for @($match.ast) Z ("^" xx 9, "^", "_", "^", "_") -> $note, $desired-accidental {
+    for (@($match.ast) Z ("^" xx 9, "^", "_", "^", "_")).flat -> $note, $desired-accidental {
         my $accidental = $context.working-accidental($note.value);
         is $accidental, $desired-accidental;
     }


### PR DESCRIPTION
The output of the zip operator `Z` used to be flattened implicitly.  This is
no longer the case, thus to reinstate the previous behaviour expected in the
context tests, the zipped lists need to be explicitly flattened before their
values are passed into the relevant for loop.  This change makes the
`context.t` tests pass.