### PR TITLE
Fix removed @*INC

### DIFF
--- a/dg-check.pl
+++ b/dg-check.pl
@@ -1,6 +1,6 @@
 use v6;
 
-BEGIN { push @*INC, "lib" }
+use lib 'lib';
 use ABC;
 
 my @matches = $*IN.slurp.comb(m/ <ABC::tune> /, :match);

--- a/playing.pl
+++ b/playing.pl
@@ -1,6 +1,6 @@
 use v6;
 
-BEGIN { push @*INC, "lib" }
+use lib 'lib';
 use ABC;
 
 my $abc = q«X:64


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.